### PR TITLE
chore: enable `ls` subcommand

### DIFF
--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -131,5 +131,6 @@ func AddCommands(root *cobra.Command, cli *CLI) {
 		newVersionCommand(cli),
 		NewInspectCommand(cli),
 		NewCatCommand(cli),
+		NewLsCommand(cli),
 	)
 }

--- a/internal/command/root_test.go
+++ b/internal/command/root_test.go
@@ -59,7 +59,7 @@ func TestAddCommands(t *testing.T) {
 	root := command.NewRootCommand()
 	command.AddCommands(root, cli)
 
-	expectedCommands := []string{"version", "inspect", "cat"}
+	expectedCommands := []string{"version", "inspect", "ls", "cat"}
 	for _, name := range expectedCommands {
 		cmd, _, err := root.Find([]string{name})
 		assert.NoError(t, err, "command %s should exist", name)
@@ -73,5 +73,5 @@ func TestAddCommands_Count(t *testing.T) {
 	command.AddCommands(root, cli)
 
 	assert.True(t, root.HasSubCommands())
-	assert.Len(t, root.Commands(), 3)
+	assert.Len(t, root.Commands(), 4)
 }


### PR DESCRIPTION
Apparently I forgot to wire up the `ls` subcommand, this fixes that.