### PR TITLE
feat: add path flag to ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 List, inspect and explore OCI container images, their layers and contents.
 
-CEK is a command-line utility for exploring OCI container images without running
+cek is a command-line utility for exploring OCI container images without running
 them. It can read images directly from local container daemons (Docker, Podman,
 containerd, etc.) or pull them from remote registries, allowing you to inspect
 metadata, browse files and directories, read file contents, and compare image
@@ -107,7 +107,7 @@ with common ancestry.
 
 ## Container Daemon Support
 
-lix works with all popular container daemons by connecting to
+cek works with all popular container daemons by connecting to
 the container daemon socket. The daemon provides access to locally cached
 images, avoiding rate limits when exploring images you've already pulled.
 


### PR DESCRIPTION
The ls` `subcommand now accepts an optional path argument, allowing users to list files in a specific directory within the image. This provides a more familiar and native ls experience, similar to what users expect on a typical filesystem. In the future, we should probably extend it to more closely mimic the full Unix `ls` interface.

For now users can use `cek ls` as following:
-   `cek ls alpine:latest`              # All files
-   `cek ls alpine:latest /etc`         # Files in /etc
-   `cek ls nginx:latest /etc/nginx`    # Files in /etc/nginx
-   `cek ls nginx:latest /etc/nginx --filter '*.conf'`  # Combine path + filter